### PR TITLE
Updates to optimize use of RAM and leverage INPUT_PULLUP

### DIFF
--- a/config.h
+++ b/config.h
@@ -23,6 +23,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#define USE_SD_VOLUME
 /**
  * These are SIO2Arduino feature definitions.
  */
@@ -38,9 +39,9 @@
 //#define LCD_DISPLAY
 
 // Uncomment this line if you are using a hardware button for image selection
-#define SELECTOR_BUTTON
+//#define SELECTOR_BUTTON
 
-// Uncomment this line if you want a reset button (automatically mounts /AUTORUN.ATR)
+// Uncomment this line if you want a reset button (automatically mounts /AUTORUN.ATR) (deprecated, AUTORUN.ATR always mounted if it exists)
 //#define RESET_BUTTON
 
 // uncomment if using an Ethernet shield for SD capabilities
@@ -132,6 +133,7 @@
   #define SIO_CALLBACK serialEvent
 #endif
 
+//#define DEBUG
 /**
  * Logging/debug config
  */

--- a/config.h
+++ b/config.h
@@ -39,7 +39,7 @@
 //#define LCD_DISPLAY
 
 // Uncomment this line if you are using a hardware button for image selection
-//#define SELECTOR_BUTTON
+#define SELECTOR_BUTTON
 
 // Uncomment this line if you want a reset button (automatically mounts /AUTORUN.ATR) (deprecated, AUTORUN.ATR always mounted if it exists)
 //#define RESET_BUTTON

--- a/disk_image.cpp
+++ b/disk_image.cpp
@@ -252,9 +252,9 @@ boolean DiskImage::loadFile(SdFile *file) {
     m_sectorSize = atrHeader->secSize;
     m_sectorReadDelay = 0;
     
-    LOG_MSG("Loaded ATR with sector size ");
+    LOG_MSG(F("Loaded ATR with sector size "));
     LOG_MSG(atrHeader->secSize);
-    LOG_MSG(": ");
+    LOG_MSG(F(": "));
     
     return true;
   }
@@ -288,7 +288,7 @@ boolean DiskImage::loadFile(SdFile *file) {
         break;
     }
 
-    LOG_MSG("Loaded PRO with sector size 128: ");
+    LOG_MSG(F("Loaded PRO with sector size 128: "));
 
     return true;
   }
@@ -383,12 +383,12 @@ boolean DiskImage::loadFile(SdFile *file) {
       file->seekSet(fileIndex);
     }
 
-    LOG_MSG("Loaded ATX with sector size 128: ");
+    LOG_MSG(F("Loaded ATX with sector size 128: "));
     return true;
   }  
 #endif
 
-  file->getFilename((char*)&filename);
+  file->getName((char*)&filename, 13);
   int len = strlen(filename);
   char *extension = filename + len - 4;
 
@@ -401,7 +401,7 @@ boolean DiskImage::loadFile(SdFile *file) {
     m_sectorSize = SECTOR_SIZE_SD;
     m_sectorReadDelay = 0;
 
-    LOG_MSG("Loaded XFD with sector size 128: ");
+    LOG_MSG(F("Loaded XFD with sector size 128: "));
     return true;
 #ifdef XEX_IMAGES    
   } else if ((!strcmp(".XEX", extension) || !strcmp(".xex", extension))) {
@@ -415,7 +415,7 @@ boolean DiskImage::loadFile(SdFile *file) {
     KBOOT_LOADER[9] = m_fileSize & 0xFF;
     KBOOT_LOADER[10] = m_fileSize >> 8;
     
-    LOG_MSG("Loaded XEX with sector size 128: ");
+    LOG_MSG(F("Loaded XEX with sector size 128: "));
     return true;
 #endif    
   }
@@ -449,4 +449,3 @@ boolean DiskImage::isDoubleDensity() {
 boolean DiskImage::isReadOnly() {
   return m_readOnly;
 }
-

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 SIO2Arduino is an open-source implementation of the Atari SIO device protocol that runs on Arduino hardware. Arduino hardware is open-source and can be assembled by hand or purchased preassembled.
 
-Note: You will need the SdFat library (https://github.com/greiman/SdFat/) in your Arduino libraries directory in order to compile.
+Note: You will need the SdFat library (https://github.com/greiman/SdFat) in your Arduino libraries directory in order to compile.
 
 For more information on SIO2Arduino, see the website at: 
 http://www.whizzosoftware.com/sio2arduino

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 SIO2Arduino is an open-source implementation of the Atari SIO device protocol that runs on Arduino hardware. Arduino hardware is open-source and can be assembled by hand or purchased preassembled.
 
-Note: You will need the SdFat library (http://code.google.com/p/sdfatlib/) in your Arduino libraries directory in order to compile.
+Note: You will need the SdFat library (https://github.com/greiman/SdFat/) in your Arduino libraries directory in order to compile.
 
 For more information on SIO2Arduino, see the website at: 
 http://www.whizzosoftware.com/sio2arduino

--- a/sdrive.cpp
+++ b/sdrive.cpp
@@ -268,49 +268,49 @@ boolean SDriveHandler::printCmdName(byte cmd) {
 #ifdef DEBUG
   switch (cmd) {
     case CMD_SDRIVE_IDENT:
-      LOG_MSG("SDRIVE IDENT");
+      LOG_MSG(F("SDRIVE IDENT"));
       break;
     case CMD_SDRIVE_INIT:
-      LOG_MSG("SDRIVE INIT");
+      LOG_MSG(F("SDRIVE INIT"));
       break;
     case CMD_SDRIVE_CHROOT:
-      LOG_MSG("SDRIVE CHROOT");
+      LOG_MSG(F("SDRIVE CHROOT"));
       break;
     case CMD_SDRIVE_SWAP_VDN:
-      LOG_MSG("SDRIVE SWAP VDN");
+      LOG_MSG(F("SDRIVE SWAP VDN"));
       break;
     case CMD_SDRIVE_GETPARAMS:
-      LOG_MSG("SDRIVE GETPARAMS");
+      LOG_MSG(F("SDRIVE GETPARAMS"));
       break;
     case CMD_SDRIVE_GET_ENTRIES:
-      LOG_MSG("SDRIVE GET ENTRIES");
+      LOG_MSG(F("SDRIVE GET ENTRIES"));
       break;
     case CMD_SDRIVE_CHDIR_VDN:
-      LOG_MSG("SDRIVE CHDIR VDN");
+      LOG_MSG(F("SDRIVE CHDIR VDN"));
       break;
     case CMD_SDRIVE_CHDIR:
-      LOG_MSG("SDRIVE CHDIR");
+      LOG_MSG(F("SDRIVE CHDIR"));
       break;
     case CMD_SDRIVE_CHDIR_UP:
-      LOG_MSG("SDRIVE CHDIR UP");
+      LOG_MSG(F("SDRIVE CHDIR UP"));
       break;
     case CMD_SDRIVE_GET20:
-      LOG_MSG("SDRIVE GET20");
+      LOG_MSG(F("SDRIVE GET20"));
       break;
     case CMD_SDRIVE_MOUNT_D0:
-      LOG_MSG("SDRIVE MOUNTvD0");
+      LOG_MSG(F("SDRIVE MOUNTvD0"));
       break;
     case CMD_SDRIVE_MOUNT_D1:
-      LOG_MSG("SDRIVE MOUNTvD1");
+      LOG_MSG(F("SDRIVE MOUNTvD1"));
       break;
     case CMD_SDRIVE_MOUNT_D2:
-      LOG_MSG("SDRIVE MOUNTvD2");
+      LOG_MSG(F("SDRIVE MOUNTvD2"));
       break;
     case CMD_SDRIVE_MOUNT_D3:
-      LOG_MSG("SDRIVE MOUNTvD3");
+      LOG_MSG(F("SDRIVE MOUNTvD3"));
       break;
     case CMD_SDRIVE_MOUNT_D4:
-      LOG_MSG("SDRIVE MOUNTvD4");
+      LOG_MSG(F("SDRIVE MOUNTvD4"));
       break;
     default:
       return false;

--- a/sio_channel.cpp
+++ b/sio_channel.cpp
@@ -127,9 +127,9 @@ void SIOChannel::processIncomingByte() {
       break;
     }
     default:
-      LOG_MSG("Ignoring byte ");
+      LOG_MSG(F("Ignoring byte "));
       LOG_MSG(b, HEX);
-      LOG_MSG(" in state ");
+      LOG_MSG(F(" in state "));
       LOG_MSG_CR(m_cmdPinState);
       break;
   }
@@ -138,9 +138,9 @@ void SIOChannel::processIncomingByte() {
 boolean SIOChannel::isChecksumValid() {
   byte chkSum = checksum((byte*)&m_cmdFrame, 4);
   if (chkSum != m_cmdFrame.checksum) {
-    LOG_MSG("Checksum failed. Calculated: ");
+    LOG_MSG(F("Checksum failed. Calculated: "));
     LOG_MSG(chkSum);
-    LOG_MSG("; received: ");
+    LOG_MSG(F("; received: "));
     LOG_MSG_CR(m_cmdFrame.checksum);
 
     return false;
@@ -298,7 +298,7 @@ void SIOChannel::doPutSector() {
       // send COMPLETE
       m_stream->write(COMPLETE);
     } else {
-      LOG_MSG_CR("Write to device error");
+      LOG_MSG_CR(F("Write to device error"));
       m_stream->write(ERR);
     }
   // otherwise, NAK it
@@ -306,9 +306,9 @@ void SIOChannel::doPutSector() {
     delay(DELAY_T4);
     m_stream->write(NAK);
 
-    LOG_MSG("Data frame checksum error: ");
+    LOG_MSG(F("Data frame checksum error: "));
     LOG_MSG(chksum, HEX);
-    LOG_MSG(" vs. ");
+    LOG_MSG(F(" vs. "));
     LOG_MSG_CR(m_sectorBuffer[sectorSize], HEX);
   }
 
@@ -352,7 +352,7 @@ void SIOChannel::cmdFormat(int deviceId, int density) {
     delay(DELAY_T5);
     m_stream->write(COMPLETE);
     
-    LOG_MSG("Sending data frame of length ");
+    LOG_MSG(F("Sending data frame of length "));
     LOG_MSG_CR(SD_SECTOR_SIZE);
 
     m_stream->write(0xFF);
@@ -372,44 +372,44 @@ void SIOChannel::dumpCommandFrame() {
 // we only compile this on DEBUG to save allocating string constants
 #ifdef DEBUG
   LOG_MSG(m_cmdFrame.deviceId, HEX);
-  LOG_MSG(" ");
+  LOG_MSG(F(" "));
   LOG_MSG(m_cmdFrame.command, HEX);
-  LOG_MSG(" ");
+  LOG_MSG(F(" "));
   LOG_MSG(m_cmdFrame.aux1, HEX);
-  LOG_MSG(" ");
+  LOG_MSG(F(" "));
   LOG_MSG(m_cmdFrame.aux2, HEX);
-  LOG_MSG(" ");
+  LOG_MSG(F(" "));
   LOG_MSG(m_cmdFrame.checksum, HEX);
-  LOG_MSG(" : ");
+  LOG_MSG(F(" : "));
   
   switch (m_cmdFrame.command) {
     case CMD_STATUS:
-      LOG_MSG("STATUS");
+      LOG_MSG(F("STATUS"));
       break;
     case CMD_POLL:
-      LOG_MSG("POLL");
+      LOG_MSG(F("POLL"));
       break;
     case CMD_READ:
-      LOG_MSG("READ ");
+      LOG_MSG(F("READ "));
       LOG_MSG(getCommandSector());
       break;
     case CMD_WRITE:
-      LOG_MSG("WRITE ");
+      LOG_MSG(F("WRITE "));
       LOG_MSG(getCommandSector());
       break;
     case CMD_PUT:
-      LOG_MSG("PUT ");
+      LOG_MSG(F("PUT "));
       LOG_MSG(getCommandSector());
       break;
     case CMD_FORMAT:
-      LOG_MSG("FORMAT");
+      LOG_MSG(F("FORMAT"));
       break;
     case CMD_FORMAT_MD:
-      LOG_MSG("FORMAT MD");
+      LOG_MSG(F("FORMAT MD"));
       break;
     default:
       if (!m_sdriveHandler.printCmdName(m_cmdFrame.command)) {
-        LOG_MSG("??");
+        LOG_MSG(F("??"));
       }
   }
   
@@ -426,4 +426,3 @@ void SIOChannel::resetCommandFrameBuffer() {
   memset(&m_cmdFrame, 0, sizeof(m_cmdFrame));
   m_cmdFramePtr = (byte*)&m_cmdFrame;
 }
-


### PR DESCRIPTION
Many strings have been moved to program storage dramatically reducing the RAM usage and the input mode on the select pin has been set to INPUT_PULLUP, utilizing the Arduino's built in pull-up resistors. This means the select button should now be wired to connect to ground and no external resistor is required. The program has been changed to look for a LOW signal on button press. Additionally a mount command was added to the setup function so that AUTORUN.ATR will be mounted if it exists. This also allows the normal Arduino reset line to be used to auto mount AUTORUN.ATR, allowing both the reset and disk change functionality to coexist by eliminating the need for a separate reset button. I am not sure why SIO2Arduino.ino is not show the individual edits like the other files do. I have built this device with the select button and an LCD display using an Arduino UNO and I have been using it successfully with my Atari 800.
